### PR TITLE
[Fix] update CML setup action to version 2 for improved functionality

### DIFF
--- a/.github/workflows/train_cml.yml
+++ b/.github/workflows/train_cml.yml
@@ -20,7 +20,10 @@ jobs:
 
       # Setup CML GitHub Action
       - name: Setup CML
-        uses: iterative/setup-cml@v1
+        uses: iterative/setup-cml@v2
+        with:
+          version: latest
+
     
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This pull request updates the CML GitHub Action in the `.github/workflows/train_cml.yml` file to use the latest version of the action and explicitly specify the version parameter.

Workflow updates:

* [`.github/workflows/train_cml.yml`](diffhunk://#diff-db1be573a8072d3cf0f6caaaa70599c446a924a51707fec16258bf779a3ca608L23-R26): Updated the `Setup CML` step to use `iterative/setup-cml@v2` instead of `v1` and added a `version: latest` parameter for clarity and to ensure the latest version is always used.